### PR TITLE
Get will now return a (*Forecast, error) pair and units are configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ func main() {
     lat := "43.6595"
     long := "-79.3433"
 
-    f := forecast.Get(key, lat, long, "now")
+    f := forecast.Get(key, lat, long, "now", forecast.SI)
     fmt.Println(f.Timezone)
     fmt.Println(f.Currently.Summary)
     fmt.Println(f.Currently.Humidity)

--- a/v2/forecast.go
+++ b/v2/forecast.go
@@ -76,14 +76,21 @@ type Forecast struct {
 	Flags     Flags
 }
 
-func Get(key string, lat string, long string, time string) (*Forecast, error) {
+type Units string
+
+const (
+	CA Units = "ca"
+	SI Units = "si"
+)
+
+func Get(key string, lat string, long string, time string, units Units) (*Forecast, error) {
 	coord := lat + "," + long
 
 	var url string
 	if time == "now" {
-		url = BASEURL + "/" + key + "/" + coord + "?units=si"
+		url = BASEURL + "/" + key + "/" + coord + "?units=" + string(units)
 	} else {
-		url = BASEURL + "/" + key + "/" + coord + "," + time + "?units=si"
+		url = BASEURL + "/" + key + "/" + coord + "," + time + "?units=" + string(units)
 	}
 
 	tr := &http.Transport{


### PR DESCRIPTION
I removed the calls to log.Fatal, since they cause a panic - I don't believe this is warranted in a library, and can be caused by minor problems such as network failure.

Additionally, InsecureSkipVerify is disabled - forecast.io seems to have a proper X509 certificate, so this should not be needed anymore.

Finally, I added two consts, CA and SI that can be passed as an argument to Get to set the units in the response.
