### PR TITLE
using default http client

### DIFF
--- a/v2/forecast.go
+++ b/v2/forecast.go
@@ -1,7 +1,7 @@
 package forecast
 
 import (
-	"crypto/tls"
+//	"crypto/tls"
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
@@ -95,11 +95,11 @@ func Get(key string, lat string, long string, time string, units Units) (*Foreca
 		url = BASEURL + "/" + key + "/" + coord + "," + time + "?units=" + string(units)
 	}
 
-	tr := &http.Transport{
+/*	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: false}, // does not seem required any longer
 	}
-	client := &http.Client{Transport: tr}
-	resp, err := client.Get(url)
+	client := &http.Client{Transport: tr}*/
+	resp, err := http.Get(url)
 
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Hi.
Since using the special tls configurations is not needed apparently, I made the library use the default http client, thus allowing me to add global caching on its requests and speed up API access in my app.

I'd love it if you could merge it so I won't have to keep a fork. 

Thanks!
