### PR TITLE
Fix outdated import in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ package main
 
 import (
     "fmt"
-    forecast "github.com/mlbright/forecast/v2"
+    forecast "github.com/mlbright/darksky/v2"
     "io/ioutil"
     "log"
     "strings"


### PR DESCRIPTION
The sample in the README did not work out-of-the-box because of the outdated path.